### PR TITLE
Add an option to set zoom factor in runner

### DIFF
--- a/electron-launcher/main.js
+++ b/electron-launcher/main.js
@@ -109,6 +109,11 @@ function createWindow () {
       mainWindow.webContents.executeJavaScript(args[p + 1], true)
     }
 
+    p = args.indexOf('--zoom-factor')
+    if (p !== -1) {
+      mainWindow.webContents.setZoomFactor(parseFloat(args[p + 1]))
+    }
+
     // this has to be before fullscreen, so when the user exits fullscreen, window is still maximized
     if (args.includes('--maximize-window') && !args.includes('--disable-resizing')) {
       mainWindow.maximize()


### PR DESCRIPTION
This option is used by adding `--zoom-factor <number>` in the runner arguments.

This can be used for accessibility purpose or to adjust old games that relied on a small resolution to the window/screen size (especially flash games using svg assets).